### PR TITLE
Add: User 테이블에 'snsId','provider' 추가 & 구글 소셜 로그인 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const session = require("express-session");
 const cookieParser = require("cookie-parser");
 
 const userRouter = require("./routes/user");
+const googleRouter = require("./routes/auth");
 const db = require("./models");
 
 const passport = require("passport");
@@ -44,6 +45,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use("/user", userRouter);
+app.use("/auth", googleRouter);
 
 app.listen(3065, () => {
   console.log("서버 실행 중!");

--- a/migrations/20230122043933-User-migration-skeleton.js
+++ b/migrations/20230122043933-User-migration-skeleton.js
@@ -1,0 +1,47 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          "Users",
+          "snsId",
+          {
+            type: Sequelize.DataTypes.STRING,
+            allowNull: false,
+          },
+          { transaction: t }
+        ),
+        queryInterface.addColumn(
+          "Users",
+          "provider",
+          {
+            type: Sequelize.DataTypes.STRING,
+            allowNull: false,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([queryInterface.removeColumn("Users", "snsId", { transaction: t }), queryInterface.removeColumn("Users", "provider", { transaction: t })]);
+    });
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};

--- a/models/user.js
+++ b/models/user.js
@@ -23,6 +23,14 @@ module.exports = class User extends Model {
           type: DataTypes.STRING(200),
           allowNull: false,
         },
+        snsId: {
+          type: DataTypes.STRING,
+          allowNull: false,
+        },
+        provider: {
+          type: DataTypes.STRING,
+          allowNull: false,
+        },
       },
       {
         // 유저 모델에 대한 셋팅

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "mysql2": "^2.3.3",
         "nodemon": "^2.0.20",
         "passport": "^0.6.0",
+        "passport-google-oauth2": "^0.2.0",
+        "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
         "sequelize": "^6.25.6",
         "sequelize-cli": "^6.5.2"
@@ -196,6 +198,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.0",
@@ -1537,6 +1547,11 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1605,6 +1620,25 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-google-oauth2": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth2/-/passport-google-oauth2-0.2.0.tgz",
+      "integrity": "sha512-62EdPtbfVdc55nIXi0p1WOa/fFMM8v/M8uQGnbcXA4OexZWCnfsEi3wo2buag+Is5oqpuHzOtI64JpHk0Xi5RQ==",
+      "dependencies": {
+        "passport-oauth2": "^1.1.2"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -1614,6 +1648,25 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -2265,6 +2318,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
     "node_modules/umzug": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.3.0.tgz",
@@ -2561,6 +2619,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "bcrypt": {
       "version": "5.1.0",
@@ -3608,6 +3671,11 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3654,12 +3722,40 @@
         "utils-merge": "^1.0.1"
       }
     },
+    "passport-google-oauth2": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth2/-/passport-google-oauth2-0.2.0.tgz",
+      "integrity": "sha512-62EdPtbfVdc55nIXi0p1WOa/fFMM8v/M8uQGnbcXA4OexZWCnfsEi3wo2buag+Is5oqpuHzOtI64JpHk0Xi5RQ==",
+      "requires": {
+        "passport-oauth2": "^1.1.2"
+      }
+    },
+    "passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
       "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
       "requires": {
         "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -4124,6 +4220,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "umzug": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "mysql2": "^2.3.3",
     "nodemon": "^2.0.20",
     "passport": "^0.6.0",
+    "passport-google-oauth2": "^0.2.0",
+    "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
     "sequelize": "^6.25.6",
     "sequelize-cli": "^6.5.2"

--- a/passport/google.js
+++ b/passport/google.js
@@ -1,0 +1,42 @@
+const passport = require("passport");
+const GoogleStrategy = require("passport-google-oauth20").Strategy;
+
+const { User } = require("../models");
+
+module.exports = () => {
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL: "http://localhost:3065/auth/google/callback",
+        passReqToCallback: true,
+      },
+      // 왜 req 를 추가해야 profile 이 읽히는지 모르겠다...
+      async (req, accessToken, refreshToken, profile, done) => {
+        console.log("google profile : ", profile);
+        try {
+          const exUser = await User.findOne({
+            where: { snsId: profile.id, provider: "google" },
+          });
+          if (exUser) {
+            return done(null, exUser);
+          } else {
+            const newUser = await User.create({
+              email: profile?.emails[0].value,
+              nickname: profile.displayName,
+              snsId: profile.id,
+              provider: "google",
+              password: "",
+              src: "",
+            });
+            return done(null, newUser);
+          }
+        } catch (err) {
+          console.error(err);
+          return done(err);
+        }
+      }
+    )
+  );
+};

--- a/passport/index.js
+++ b/passport/index.js
@@ -1,5 +1,7 @@
 const passport = require("passport");
 const local = require("./local");
+const google = require("./google");
+
 const { User } = require("../models");
 
 module.exports = () => {
@@ -18,4 +20,5 @@ module.exports = () => {
   });
 
   local();
+  google();
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,31 @@
+const express = require("express");
+const passport = require("passport");
+
+const router = express.Router();
+
+// google login
+router.get(
+  "/google",
+  passport.authenticate("google", {
+    scope: ["email", "profile"],
+  })
+);
+
+// google login 성공과 실패 리다이렉트
+router.get(
+  "/google/callback",
+  passport.authenticate("google", {
+    successRedirect: "http://localhost:3000/closet",
+    failureRedirect: "http://localhost:3000/userlogin",
+  })
+);
+
+// logout
+router.get("/logout", (req, res) => {
+  req.session.destroy((err) => {
+    req.logout();
+    res.redirect("http://localhost:3000/userlogin");
+  });
+});
+
+module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,6 +11,7 @@ router.get("/", async (req, res, next) => {
   // GET /user
   try {
     if (req.user) {
+      console.log(req.user);
       const fullUserWithoutPassword = await User.findOne({
         where: { id: req.user.id },
         attributes: {
@@ -69,6 +70,7 @@ router.post("/logout", isLoggedIn, async (req, res, next) => {
       return next(err);
     }
     req.session.destroy();
+    // res.clearCookie();
     res.send("로그아웃 되었습니다.");
   });
 });


### PR DESCRIPTION
### 시퀄라이즈 마이그레이션 실행

- 구글 소셜 로그인을 위해 기존 테이블에서 업데이트가 필요
- 구글을 포함 어느 소셜 출처인지를 위한 'provider', 소셜에서 주어지는 id 를 저장할 'snsId'
- 주의할 점은 직접 테이블에 변경내역을 추가하고, 마이그레이션 파일 생성 후 바뀐 부분을 역시나 반영한다.

### 구글 소셜 로그인 구현

- 기존 로그인의 테이블에 구글 아이디를 저장하기 위해, 구글 API 설정을 서버 로컬로 지정
- passport-google-oauth20 을 통해서 구글 내 아이디와 이메일 등 개인 정보를 가져온다
- 이후 개인 정보를 통해 만약 데이터베이스에 존재하면 생략, 없다면 데이터베이스에 아이디를 넣어준다.
- 데이터베이스에 데이터가 잘 들어와있음을 확인
- 로그아웃 시 세션 id 파기로 인해 성공적으로 로그아웃 진행 완료